### PR TITLE
Issue 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Cordova Plugin for using WebSockets
 ======
+[![npm version](https://badge.fury.io/js/cordova-plugin-advanced-websocket.svg)](https://badge.fury.io/js/cordova-plugin-advanced-websocket)
+[![downloads](https://img.shields.io/npm/dt/cordova-plugin-advanced-websocket.svg)](https://www.npmjs.com/package/cordova-plugin-advanced-websocket)
+[![MIT Licence](https://badges.frapsoft.com/os/mit/mit.png)](https://opensource.org/licenses/mit-license.php)
 
 WebSocket plugin that supports custom headers, self-signed certificates, periodical sending of pings (ping-pong to keep connection alive and detect sudden connection loss when no closing frame is received).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-advanced-websocket",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "cordova": {
     "id": "cordova-plugin-advanced-websocket",
     "platforms": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-advanced-websocket"
-    version="1.1.3">
+    version="1.1.4">
     <name>Cordova advanced websocket plugin</name>
     <description></description>
     <license>MIT</license>

--- a/src/android/com/homecontrol/CordovaWebsocketPlugin.java
+++ b/src/android/com/homecontrol/CordovaWebsocketPlugin.java
@@ -216,8 +216,11 @@ public class CordovaWebsocketPlugin extends CordovaPlugin {
             this.recvCallbackContext = recvCallbackContext;
             
             if (!this.messageBuffer.isEmpty() && this.flushReceivedBuffer){
-                for(PluginResult message : this.messageBuffer){
+                Iterator<PluginResult> messageIterator = this.messageBuffer.iterator();
+                while(messageIterator.hasNext()){
+                    PluginResult message = messageIterator.next();
                     recvCallbackContext.sendPluginResult(message);
+                    messageIterator.remove();
                 }
             }
         }

--- a/src/ios/CordovaWebsocketPlugin.m
+++ b/src/ios/CordovaWebsocketPlugin.m
@@ -21,9 +21,10 @@
 - (void)wsAddListeners:(CDVInvokedUrlCommand*)command;
 {
     NSString* webSocketId = [command argumentAtIndex:0];
+    BOOL flushRecvBuffer = [command argumentAtIndex:1];
     WebSocketAdvanced* ws = [webSockets valueForKey:webSocketId];
     if (ws != nil) {
-        [ws wsAddListeners:command.callbackId];
+        [ws wsAddListeners:command.callbackId flushRecvBuffer:flushRecvBuffer];
     }
 }
 

--- a/src/ios/WebSocketAdvanced.h
+++ b/src/ios/WebSocketAdvanced.h
@@ -18,7 +18,7 @@
 - (instancetype)initWithOptions:(NSDictionary*)wsOptions 
                 commandDelegate:(id<CDVCommandDelegate>)commandDelegate
                 callbackId:(NSString*)callbackId;
-- (void)wsAddListeners:(NSString*)recvCallbackId;
+- (void)wsAddListeners:(NSString*)recvCallbackId flushRecvBuffer:(BOOL)flushRecvBuffer;
 - (void)wsSendMessage:(NSString*)message;
 - (void)wsClose;
 - (void)wsClose:(NSInteger)code reason:(NSString*)reason;

--- a/src/ios/WebSocketAdvanced.h
+++ b/src/ios/WebSocketAdvanced.h
@@ -11,7 +11,6 @@
     NSInteger _pingCount;
     NSInteger _pongCount;
     BOOL _awaitingPong;
-    BOOL _flushReceivedBuffer;
     NSMutableArray* _messageBuffer;
 }
 @property NSString* webSocketId;

--- a/src/ios/WebSocketAdvanced.m
+++ b/src/ios/WebSocketAdvanced.m
@@ -51,11 +51,11 @@
     _recvCallbackId = recvCallbackId;
     
     if([_messageBuffer count] > 0 && flushRecvBuffer) {
-        for(PluginResult *message in _messageBuffer) {
-            [_commandDelegate sendPluginResult:pluginResult callbackId:recvCallbackId];
+        for(CDVPluginResult* message in _messageBuffer) {
+            [_commandDelegate sendPluginResult:message callbackId:recvCallbackId];
         }
     }
-    _messageBuffer.removeAllObjects();
+    [_messageBuffer removeAllObjects];
 }
 
 - (void)wsSendMessage:(NSString*)message;
@@ -184,7 +184,7 @@
         [_commandDelegate sendPluginResult:pluginResult callbackId:_recvCallbackId];
     }
     else {
-        _messageBuffer.add(pluginResult);
+        [_messageBuffer addObject:pluginResult];
     }
 }
 

--- a/src/ios/WebSocketAdvanced.m
+++ b/src/ios/WebSocketAdvanced.m
@@ -12,7 +12,7 @@
     NSNumber* pingInterval =    [wsOptions valueForKey:@"pingInterval"];
     NSDictionary* wsHeaders =   [wsOptions valueForKey:@"headers"];
     BOOL acceptAllCerts =       [wsOptions valueForKey:@"acceptAllCerts"];
-    _flushReceivedBuffer =      [wsOptions valueForKey:@"flushReceivedBuffer"];
+
     _messageBuffer =            [[NSMutableArray alloc] init];
 
     NSTimeInterval timeoutInterval = timeout ? (timeout.doubleValue / 1000) : 0;
@@ -46,11 +46,11 @@
     return self;
 }
 
-- (void)wsAddListeners:(NSString*)recvCallbackId;
+- (void)wsAddListeners:(NSString*)recvCallbackId flushRecvBuffer:(BOOL)flushRecvBuffer;
 {
     _recvCallbackId = recvCallbackId;
     
-    if([_messageBuffer count] > 0 && _flushReceivedBuffer) {
+    if([_messageBuffer count] > 0 && flushRecvBuffer) {
         for(PluginResult *message in _messageBuffer) {
             [_commandDelegate sendPluginResult:pluginResult callbackId:recvCallbackId];
         }

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -15,8 +15,8 @@ var CordovaWebsocketPlugin = {
             if (success != undefined && typeof success === "function") {
                 success(data);
             }
-
-            exec(listener, listener, PLUGIN_NAME, 'wsAddListeners', [data.webSocketId]);
+            let flushRecvBuffer = true;
+            exec(listener, listener, PLUGIN_NAME, 'wsAddListeners', [data.webSocketId, flushRecvBuffer]);
         }
         exec(connectSuccess, error, PLUGIN_NAME, 'wsConnect', [wsOptions]);
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements message buffer for both platforms. Buffers stores messages that are received before any listener is set. Once listener is set stored messages will be flushed.

Also new parameter is introduced to make usage of buffer optional.

**Which issue(s) this PR fixes**
#9 

**How was this tested?**
Sending websocket messages to Ionic application while app is starting up. Both on Android and iOS.

**Is this PR backwards compatible**
Yes