### PR TITLE
don't use block scoped definitions (Breaks Android 6)

### DIFF
--- a/www/plugin.js
+++ b/www/plugin.js
@@ -15,7 +15,7 @@ var CordovaWebsocketPlugin = {
             if (success != undefined && typeof success === "function") {
                 success(data);
             }
-            let flushRecvBuffer = true;
+            var flushRecvBuffer = true;
             exec(listener, listener, PLUGIN_NAME, 'wsAddListeners', [data.webSocketId, flushRecvBuffer]);
         }
         exec(connectSuccess, error, PLUGIN_NAME, 'wsConnect', [wsOptions]);


### PR DESCRIPTION
Fixes Error reported:

```
03-17 11:03:34.177  4100  4100 I chromium: [INFO:CONSOLE(19)] "Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode", source: file:///android_asset/www/plugins/cordova-plugin-advanced-websocket/www/plugin.js (19)
```

(Android 6.0 still has the [largest deployment base](https://developer.android.com/about/dashboards?authuser=1), so it may be worthwhile to support it)

