### PR TITLE
Add Browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ WebSocket plugin that supports custom headers, self-signed certificates, periodi
 
 * Android (uses [OkHttp](https://github.com/square/okhttp) as underlaying library)
 * iOS (uses [SocketRocket](https://github.com/facebook/SocketRocket) as underlaying library)
+* Browser (uses [WebSocket Web API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) as underlaying library)
 
 ### Android
 
@@ -51,9 +52,9 @@ CordovaWebsocketPlugin.wsConnect(options, receiveCallback, successCallback, fail
 - __options__: Object containing WebSocket url and other properties needed for opening WebSocket:
     - __url__: _string_; Url of WebSocket you want to connect to. This is the only mandatory property in __options__.
     - __timeout?__: _number_; Request timeout in milliseconds. (optional, defaults to 0)
-    - __pingInterval?__: _number_; Ping interval in milliseconds if you want to keep WebSocket open and detect automatically dead WebSocket when Pongs stop returning. If you set it to 0, Pings won't be sent. (optional, defaults to 0)
-    - __headers?__: _object_; Object containing custom request headers you want to send when opening WebSocket. Object keys are used as Header names, and values are used as Header values. (optional)
-    - __acceptAllCerts?__: _boolean_; Set this to true if you are using secure version of WebSocket (url starts with "wss://") and you want to accept all certificates regardles of their validity. Useful when your WebSocket is using self-signed certificates. (optional, defaults to false)
+    - __pingInterval?__: _number_; Ping interval in milliseconds if you want to keep WebSocket open and detect automatically dead WebSocket when Pongs stop returning. If you set it to 0, Pings won't be sent. (optional, defaults to 0. iOS/Android only)
+    - __headers?__: _object_; Object containing custom request headers you want to send when opening WebSocket. Object keys are used as Header names, and values are used as Header values. (optional. iOS/Android only)
+    - __acceptAllCerts?__: _boolean_; Set this to true if you are using secure version of WebSocket (url starts with "wss://") and you want to accept all certificates regardles of their validity. Useful when your WebSocket is using self-signed certificates. (optional, defaults to false. iOS/Android only)
 - __receiveCallback__: Receive callback function that is invoked with every message received through WebSocket and also when WebSocket is closed.
 - __successCallback__: Success callback function that is invoked with successfull connect to WebSocket.
 - __failureCallback__: Error callback function, invoked when connecting to WebSocket failed for whatever reason.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "id": "cordova-plugin-advanced-websocket",
     "platforms": [
       "android",
-      "ios"
+      "ios",
+      "browser"
     ]
   },
   "repository": {
@@ -16,7 +17,8 @@
     "cordova",
     "websocket",
     "cordova-ios",
-    "cordova-android"
+    "cordova-android",
+    "cordova-browser"
   ],
   "description": "Cordova Plugin for using WebSockets",
   "author": "HomeControl AS",

--- a/plugin.xml
+++ b/plugin.xml
@@ -51,5 +51,16 @@
         
         <framework src="SocketRocket" type="podspec" spec="0.5.1" />
     </platform>
+
+    <!-- browser -->
+    <platform name="browser">
+        <config-file target="config.xml" parent="/*">
+            <feature name="CordovaWebsocketPlugin">
+                <param name="browser-package" value="CordovaWebsocketPlugin" />
+            </feature>
+        </config-file>  
+        <js-module src="src/browser/CordovaWebsocketPlugin.js" name="CordovaWebsocketPlugin">
+            <clobbers target="CordovaWebsocketPlugin" />
+        </js-module>
+    </platform>
 </plugin>
-        

--- a/src/browser/CordovaWebsocketPlugin.js
+++ b/src/browser/CordovaWebsocketPlugin.js
@@ -1,0 +1,84 @@
+const WS_ABNORMAL_CODE = 1006;
+
+const connections = {};
+
+const createId = function() {
+    return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+};
+
+const wsAddListeners = function(webSocketId, success, error) {
+    const webSocket = connections[webSocketId];
+
+    webSocket.onmessage = function(event) {
+        success({
+            webSocketId: webSocketId,
+            message: event.data,
+            callbackMethod: "onMessage"
+        });
+    };
+
+    webSocket.onclose = function(event) {
+        error({
+            webSocketId: webSocketId,
+            code: event.code,
+            reason: event.reason,
+            callbackMethod: "onClose"
+        });
+        wsRemoveListeners(webSocketId);
+    };
+};
+
+const wsRemoveListeners = function(webSocketId) {
+    const webSocket = connections[webSocketId];
+    webSocket.onmessage = undefined;
+    webSocket.onclose = undefined
+    connections[webSocketId] = undefined;
+};
+
+const CordovaWebsocketPlugin = {
+    wsConnect: function(wsOptions, listener, success, error) {
+        const webSocketId = createId();
+        const webSocket = new WebSocket(wsOptions.url);
+
+        let timeoutHandler;
+        if (wsOptions.timeout && wsOptions.timeout > 0) {
+            timeoutHandler = setTimeout(function() {
+                webSocket.close();
+            }, wsOptions.timeout);
+        }
+
+        webSocket.onopen = function() {
+            if (timeoutHandler) {
+                clearTimeout(timeoutHandler);
+            }
+            connections[webSocketId] = webSocket;
+            wsAddListeners(webSocketId, listener, listener);
+            success({ webSocketId: webSocketId, code: 0 });
+        };
+
+        webSocket.onerror = function() {
+            error({
+                webSocketId: webSocketId,
+                code: WS_ABNORMAL_CODE,
+                reason: "Error connecting to " + wsOptions.url,
+                callbackMethod: "onFail"
+            });
+        }
+
+    },
+    wsSend: function(webSocketId, message) {
+        const webSocket = connections[webSocketId];
+        if (webSocket) {
+            webSocket.send(message);
+        }
+    },
+    wsClose: function(webSocketId, code, reason) {
+        const webSocket = connections[webSocketId];
+        if (webSocket) {
+            webSocket.close(code, reason);
+            wsRemoveListeners(webSocketId);
+        }
+    }
+};
+
+module.exports = CordovaWebsocketPlugin;


### PR DESCRIPTION
This PR adds support for the Cordova browser platform.

Some limitations
- As far as I am aware there is no browser API for sending ping/pong frames. It looks like this is managed by the browser itself. I was able to verify that Firefox, Chrome and Safari are all sending pong frames.
- The WebSockets Web API does not support custom headers. So the `headers` property is ignored
- Since this is running in the browser, there's no way to accept all certificates regardless of their validity, so the `acceptAllCerts` is also ignored.

I have created an example cordova browser project which can be used to test: https://github.com/adrianfalleiro/cordova-plugin-advanced-websocket-browser-example